### PR TITLE
json server start up script

### DIFF
--- a/run_api.sh
+++ b/run_api.sh
@@ -1,0 +1,1 @@
+json-server -w src/api/PlanitAPI.json


### PR DESCRIPTION
Add a script to start the `json-server`

NOTE: the script has to be run from the root level of the project.