### PR TITLE
Add port to script

### DIFF
--- a/run_api.sh
+++ b/run_api.sh
@@ -1,1 +1,2 @@
-json-server -w src/api/PlanitAPI.json
+json-server -w src/api/PlanitAPI.json -p 8088
+


### PR DESCRIPTION
I forgot the port on the json-server script. This change allows the app to access the api.